### PR TITLE
Feature/getOrCreateStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build"
   ],
   "scripts": {
+    "quick-test": "npm run build; node test/quick-test.js",
     "build": "rm -rf ./build && babel src --out-dir build",
     "build-doc": "npm run clean && npm run build && node ./node_modules/jsdoc/jsdoc.js --package ./package.json -c ./jsdoc/conf.json -d docs",
     "test": "npm run build && mocha --compilers js:babel-core/register --recursive",

--- a/src/actor.js
+++ b/src/actor.js
@@ -290,6 +290,55 @@ export const setValue = (key, value, options, callback = null) => {
     return nodeifyPromise(promise, callback);
 };
 
+/**
+ * @memberof module:Apify
+ * @function
+ * @description <p>
+ * Gets or creates a key-value store with the passed name or ID.
+ * The key-value store is retrieved or created automatically for each act run. 
+ * The ID is passed by the user calling the function instead of the `APIFY_DEFAULT_KEY_VALUE_STORE_ID` 
+ * enviroment variable passed by the Actor platform.
+ * 
+ * It is used to save the `INPUT` and `OUTPUT` of an act in a named key-value store with or 
+ * without previous results. Useful in situations where the user wants to check for changes
+ * in previous stored values.
+ * 
+ * Keep in mind that the store can be used for storage of any other values under arbitrary keys.
+ * </p>
+ * 
+ * <p>Example usage</p>
+ * <pre><code class="language-javascript">const Store = await Apify.setStore('store-123');
+ * console.log('My Store:');
+ * console.dir(Store);
+ * 
+ * const input = await Store.getValue('INPUT');
+ * console.log('My input:');
+ * console.dir(input);
+ * </code></pre>
+ * 
+ * <p>
+ * The result of the function is an object with the `getValue` and `setValue` methods.
+ * The Store object methods behave exactly like the `Apify.getValue` and `Apify.setValue` methods,
+ * with the exception that it sets and gets store keys from a named key-value store.
+ * </p>
+ * 
+ * <p>
+ * The definition of the `APIFY_DEV_KEY_VALUE_STORE_DIR` environment variable will have no effect
+ * on this method.
+ * 
+ * The directory must exist or an error is thrown. If the file does not exists, the returned value is `null`.
+ * The file is assumed to have a content type specified in the `APIFY_DEV_KEY_VALUE_STORE_CONTENT_TYPE`
+ * environment variable, or `application/json` if not set.
+ * This feature is useful for local development and debugging of your acts.
+ * </p>
+ * @param {String} nameOrId - The name or ID for the key-value store.
+ * @param {Function} [callback] Optional callback. Function returns a promise if not provided.
+ * @returns {Promise} - Returns a promise if no callback was passed or and object with the `getValue` and `setValue` methods.
+ */
+export const setStore = (nameOrId, callback = null) => {
+
+};
+
 
 /**
  * @memberof module:Apify

--- a/src/actor.js
+++ b/src/actor.js
@@ -346,23 +346,25 @@ class Store {
             if (!key || !_.isString(key)) {
                 throw new Error(`Parameter "key" of type String must be provided`);
             }
+
             const modifiedOpts = this.modifyOptionsWithPrivates({ key });            
-            return keyValueStores.getRecord(modifiedOpts).then(record => (
-                record && record.body || null
-            )).catch(error => { 
-                throw new Error(error);
-            });
+
+            return keyValueStores.getRecord(modifiedOpts)
+                .then(record => record && record.body || null)
+                .catch(error => { throw new Error(error); });
         }
 
         this.setValue = (key, value, options = {}) => {
             if (!key || !_.isString(key)) {
                 throw new Error(`Parameter "key" of type String must be provided`);
             }
+
             const updatedOpts = Object.assign({}, options, { key, body: value });
             const modifiedOpts = this.modifyOptionsWithPrivates(updatedOpts);            
             const opts = typeof modifiedOpts.body === 'object' ? 
                 Object.assign(modifiedOpts, { body: JSON.stringify(modifiedOpts.body) })
                 : modifiedOpts;  
+
             return keyValueStores.putRecord(opts)
                 .then(response => response)
                 .catch(error => { throw new Error(error); });

--- a/src/actor.js
+++ b/src/actor.js
@@ -198,7 +198,7 @@ export const getValue = (key, callback = null) => {
  * @param {Function} [callback] Optional callback. Function returns a promise if not provided.
  * @returns {Promise} Returns a promise if `callback` was not provided.
  */
-export const setValue = (key, value, options, callback = null)  => {
+export const setValue = (key, value, options, callback = null) => {
     if (!key || !_.isString(key)) throw new Error('The "key" parameter must be a non-empty string');
 
     // contentType is optional
@@ -295,37 +295,40 @@ export const setValue = (key, value, options, callback = null)  => {
  * @function
  * @description <p>
  * Gets or creates a key-value store with the passed name or ID.
- * The key-value store is retrieved or created automatically for each act run. 
- * The ID is passed by the user calling the function instead of the `APIFY_DEFAULT_KEY_VALUE_STORE_ID` 
+ * The key-value store is retrieved or created automatically for each act run.
+ * The ID is passed by the user calling the function instead of the `APIFY_DEFAULT_KEY_VALUE_STORE_ID`
  * enviroment variable passed by the Actor platform.
- * 
- * It is used to save the `INPUT` and `OUTPUT` of an act in a named key-value store with or 
+ *
+ * It is used to save the `INPUT` and `OUTPUT` of an act in a named key-value store with or
  * without previous results. Useful in situations where the user wants to check for changes
- * in previous stored values.
- * 
+ * in previous stored values or keep a STATE output for comparisons.
+ *
  * Keep in mind that the store can be used for storage of any other values under arbitrary keys.
  * </p>
- * 
+ *
  * <p>Example usage</p>
  * <pre><code class="language-javascript">const Store = await Apify.getOrCreateStore('store-123');
  * console.log('My Store:');
  * console.dir(Store);
- * 
- * const input = await Store.getValue('INPUT');
- * console.log('My input:');
- * console.dir(input);
+ *
+ * const previousState = await Store.getValue('STATE');
+ * console.log('My previous state:');
+ * console.dir(previousState);
+ * // ...
+ * const nextState = Object.assign({}, { newRecord: 'your new record!' }, previousState);
+ * await Store.setValue('STATE', nextState);
  * </code></pre>
- * 
+ *
  * <p>
  * The result of the function is an object with the `getValue` and `setValue` methods.
  * The Store object methods behave exactly like the `Apify.getValue` and `Apify.setValue` methods,
  * with the exception that it sets and gets store keys from a named key-value store.
  * </p>
- * 
+ *
  * <p>
  * The definition of the `APIFY_DEV_KEY_VALUE_STORE_DIR` environment variable will have no effect
  * on this method.
- * 
+ *
  * The directory must exist or an error is thrown. If the file does not exists, the returned value is `null`.
  * The file is assumed to have a content type specified in the `APIFY_DEV_KEY_VALUE_STORE_CONTENT_TYPE`
  * environment variable, or `application/json` if not set.
@@ -340,39 +343,44 @@ export const setValue = (key, value, options, callback = null)  => {
 const privatize = new WeakMap();
 class Store {
     constructor(keyValueStores, { id: storeId }) {
-        privatize.set(this, { keyValueStores, storeId });
+        privatize.set(this, { storeId });
 
         this.getValue = (key) => {
             if (!key || !_.isString(key)) {
-                throw new Error(`Parameter "key" of type String must be provided`);
+                throw new Error('Parameter "key" of type String must be provided');
             }
 
-            const modifiedOpts = this.modifyOptionsWithPrivates({ key });            
+            const modifiedOpts = this.modifyOptionsWithPrivates({ key });
 
             return keyValueStores.getRecord(modifiedOpts)
-                .then(record => record && record.body || null)
-                .catch(error => { throw new Error(error); });
-        }
+                .then(record => (record && record.body) || null)
+                .catch((error) => { throw new Error(error); });
+        };
 
         this.setValue = (key, value, options = {}) => {
             if (!key || !_.isString(key)) {
-                throw new Error(`Parameter "key" of type String must be provided`);
+                throw new Error('Parameter "key" of type String must be provided');
             }
 
-            const updatedOpts = Object.assign({}, options, { key, body: value });
-            const modifiedOpts = this.modifyOptionsWithPrivates(updatedOpts);            
-            const opts = typeof modifiedOpts.body === 'object' ? 
-                Object.assign(modifiedOpts, { body: JSON.stringify(modifiedOpts.body) })
-                : modifiedOpts;  
+            let body;
+            if (value && _.isString(value)) {
+                body = value;
+            } else if (value && _.isObject(value)) {
+                body = JSON.stringify(value);
+            } else {
+                throw new Error('Parameter "value" of type Object must be provided');
+            }
 
-            return keyValueStores.putRecord(opts)
+            const updatedOpts = Object.assign({}, options, { key, body });
+            const modifiedOpts = this.modifyOptionsWithPrivates(updatedOpts);
+            return keyValueStores.putRecord(modifiedOpts)
                 .then(response => response)
-                .catch(error => { throw new Error(error); });
-        }
+                .catch((error) => { throw new Error(error); });
+        };
     }
 
     modifyOptionsWithPrivates(options) {
-        const { storeId, keyValueStores } = privatize.get(this);
+        const { storeId } = privatize.get(this);
         return Object.assign({}, options, { storeId });
     }
 }
@@ -391,7 +399,7 @@ export const getOrCreateStore = (storeName, callback = null) => {
             throw new Error(error);
         });
     }
-    return; 
+    keyValueStores.getOrCreateStore({ storeName }, callback);
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 
 import { setPromisesDependency, getPromisesDependency } from './utils';
-import { main, readyFreddy, getEnv, getValue, setValue, setStore, apifyClient, call, getMemoryInfo } from './actor';
+import { main, readyFreddy, getEnv, getValue, setValue, getOrCreateStore, apifyClient, call, getMemoryInfo } from './actor';
 import { launchPuppeteer } from './puppeteer';
 import { browse, launchWebDriver } from './webdriver';
 
@@ -13,7 +13,7 @@ const Apify = {
     getEnv,
     getValue,
     setValue,
-    setStore,
+    getOrCreateStore,
     call,
     readyFreddy,
     setPromisesDependency,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 
 import { setPromisesDependency, getPromisesDependency } from './utils';
-import { main, readyFreddy, getEnv, getValue, setValue, apifyClient, call, getMemoryInfo } from './actor';
+import { main, readyFreddy, getEnv, getValue, setValue, setStore, apifyClient, call, getMemoryInfo } from './actor';
 import { launchPuppeteer } from './puppeteer';
 import { browse, launchWebDriver } from './webdriver';
 
@@ -13,6 +13,7 @@ const Apify = {
     getEnv,
     getValue,
     setValue,
+    setStore,
     call,
     readyFreddy,
     setPromisesDependency,

--- a/test/actor.js
+++ b/test/actor.js
@@ -1030,25 +1030,25 @@ describe('Apify.getOrCreateStore()', () => {
         });
     });
 
-    // const setValueStore = storeFabric('my-setValue-store');
-    // it('returns STATE value after calling setValue method', () => {
-    //     const mockState = JSON.stringify({
-    //         testString: 'String',
-    //         testNumber: 3e6,
-    //         testArray: [1, 2, 3, 4],
-    //         testObject: {
-    //             key: 'value',
-    //         },
-    //     });
-    //     setValueStore.then((store) => {
-    //         return store.setValue('STATE', mockState).then(() => {
-    //             return store.getValue('STATE').then((state) => {
-    //                 expect(state).to.be.a('string');
-    //                 expect(state).to.eql(mockState);
-    //             }).catch(error => console.log('Oh no 2!', error));
-    //         });
-    //     });
-    // });
+    const setValueStore = storeFabric('my-setValue-store');
+    it('returns STATE value after calling setValue method', () => {
+        const mockState = JSON.stringify({
+            testString: 'String',
+            testNumber: 3e6,
+            testArray: [1, 2, 3, 4],
+            testObject: {
+                key: 'value',
+            },
+        });
+        setValueStore.then((store) => {
+            return store.setValue('STATE', mockState).then(() => {
+                return store.getValue('STATE').then((state) => {
+                    expect(state).to.be.a('string');
+                    expect(state).to.eql(mockState);
+                }).catch(error => console.log('Oh no 2!', error));
+            });
+        });
+    });
 });
 
 describe('Apify.events', () => {

--- a/test/actor.js
+++ b/test/actor.js
@@ -936,25 +936,25 @@ describe('Apify.setValue()', () => {
     });
 });
 
-describe('Apify.setStore', () => {
+describe('Apify.getOrCreateStore()', () => {
     it('throws on invalid args', () => {
-        const keyErrMsg = 'The "nameOrId" parameter must be a non-empty string';
-        expect(() => { Apify.setStore(); }).to.throw(Error, keyErrMsg);
-        expect(() => { Apify.setStore('', null); }).to.throw(Error, keyErrMsg);
-        expect(() => { Apify.setStore('', 'some value'); }).to.throw(Error, keyErrMsg);
-        expect(() => { Apify.setStore({}, 'some value'); }).to.throw(Error, keyErrMsg);
-        expect(() => { Apify.setStore(123, 'some value'); }).to.throw(Error, keyErrMsg);
+        const keyErrMsg = 'The "storeName" parameter must be a non-empty string';
+        expect(() => { Apify.getOrCreateStore(); }).to.throw(Error, keyErrMsg);
+        expect(() => { Apify.getOrCreateStore('', null); }).to.throw(Error, keyErrMsg);
+        expect(() => { Apify.getOrCreateStore('', 'some value'); }).to.throw(Error, keyErrMsg);
+        expect(() => { Apify.getOrCreateStore({}, 'some value'); }).to.throw(Error, keyErrMsg);
+        expect(() => { Apify.getOrCreateStore(123, 'some value'); }).to.throw(Error, keyErrMsg);
     });
 
     it('returns a Promise', () => {
-        const promise = Apify.setStore('my-store');
+        const promise = Apify.getOrCreateStore('my-store');
         expect(promise).to.be.a('promise');
     });
 
     const storeFabric = (nameOrId) => {
         return new Promise((resolve, reject) => {
             try {
-                resolve(Apify.setStore(nameOrId));
+                resolve(Apify.getOrCreateStore(nameOrId));
             } catch (error) {
                 reject(error);
             }
@@ -973,7 +973,7 @@ describe('Apify.setStore', () => {
 
     it('throws on invalid args pass to the getValue method', () => {
         promiseStore.then((store) => {
-            const keyErrMsg = 'The "key" parameter must be a non-empty string';
+            const keyErrMsg = 'Parameter "key" of type String must be provided';
             expect(() => { store.getValue(); }).to.throw(Error, keyErrMsg);
             expect(() => { store.getValue({}); }).to.throw(Error, keyErrMsg);
             expect(() => { store.getValue(''); }).to.throw(Error, keyErrMsg);
@@ -983,7 +983,7 @@ describe('Apify.setStore', () => {
 
     it('throws on invalid args pass to the setValue method', () => {
         promiseStore.then((store) => {
-            const keyErrMsg = 'The "key" parameter must be a non-empty string';
+            const keyErrMsg = 'Parameter "key" of type String must be provided';
             expect(() => { store.setValue(); }).to.throw(Error, keyErrMsg);
             expect(() => { store.setValue('', null); }).to.throw(Error, keyErrMsg);
             expect(() => { store.setValue('', 'some value'); }).to.throw(Error, keyErrMsg);
@@ -1021,14 +1021,14 @@ describe('Apify.setStore', () => {
         });
     });
 
-    // const testStore = storeFabric('my-test-store');
-    // it('returns null from a non-existent key in getValue method', () => {
-    //     testStore.then((store) => {
-    //         return store.getValue('INPUT').then((input) => {
-    //             return expect(input).to.eql(null);
-    //         });
-    //     });
-    // });
+    const testStore = storeFabric('my-test-store');
+    it('returns null from a non-existent key in getValue method', () => {
+        testStore.then((store) => {
+            return store.getValue('INPUT').then((input) => {
+                return expect(input).to.eql(null);
+            });
+        });
+    });
 
     // const setValueStore = storeFabric('my-setValue-store');
     // it('returns STATE value after calling setValue method', () => {

--- a/test/actor.js
+++ b/test/actor.js
@@ -1021,15 +1021,14 @@ describe('Apify.setStore', () => {
         });
     });
 
-    const testStore = storeFabric('my-test-store');
-    it('returns an empty INPUT value from non-existent key in getValue method', () => {
-        testStore.then((store) => {
-            return store.getValue('INPUT').then((input) => {
-                expect(input).to.be.a('string');
-                expect(input).to.eql('');
-            }).catch(error => console.log('Oh no! 1', error));
-        }).catch(error => console.log('Oh no! 2', error));
-    });
+    // const testStore = storeFabric('my-test-store');
+    // it('returns null from a non-existent key in getValue method', () => {
+    //     testStore.then((store) => {
+    //         return store.getValue('INPUT').then((input) => {
+    //             return expect(input).to.eql(null);
+    //         });
+    //     });
+    // });
 
     // const setValueStore = storeFabric('my-setValue-store');
     // it('returns STATE value after calling setValue method', () => {

--- a/test/actor.js
+++ b/test/actor.js
@@ -936,6 +936,122 @@ describe('Apify.setValue()', () => {
     });
 });
 
+describe('Apify.setStore', () => {
+    it('throws on invalid args', () => {
+        const keyErrMsg = 'The "nameOrId" parameter must be a non-empty string';
+        expect(() => { Apify.setStore(); }).to.throw(Error, keyErrMsg);
+        expect(() => { Apify.setStore('', null); }).to.throw(Error, keyErrMsg);
+        expect(() => { Apify.setStore('', 'some value'); }).to.throw(Error, keyErrMsg);
+        expect(() => { Apify.setStore({}, 'some value'); }).to.throw(Error, keyErrMsg);
+        expect(() => { Apify.setStore(123, 'some value'); }).to.throw(Error, keyErrMsg);
+    });
+
+    it('returns a Promise', () => {
+        const promise = Apify.setStore('my-store');
+        expect(promise).to.be.a('promise');
+    });
+
+    const storeFabric = (nameOrId) => {
+        return new Promise((resolve, reject) => {
+            try {
+                resolve(Apify.setStore(nameOrId));
+            } catch (error) {
+                reject(error);
+            }
+        });
+    };
+
+    const promiseStore = storeFabric('my-store');
+    it('returns an Object with a setValue and getValue method', () => {
+        promiseStore.then((store) => {
+            expect(store).to.be.an('object');
+            expect(Object.keys(store)).to.eql(['getValue', 'setValue']);
+            expect(store.getValue).to.be.a('function');
+            expect(store.setValue).to.be.a('function');
+        });
+    });
+
+    it('throws on invalid args pass to the getValue method', () => {
+        promiseStore.then((store) => {
+            const keyErrMsg = 'The "key" parameter must be a non-empty string';
+            expect(() => { store.getValue(); }).to.throw(Error, keyErrMsg);
+            expect(() => { store.getValue({}); }).to.throw(Error, keyErrMsg);
+            expect(() => { store.getValue(''); }).to.throw(Error, keyErrMsg);
+            expect(() => { store.getValue(null); }).to.throw(Error, keyErrMsg);
+        });
+    });
+
+    it('throws on invalid args pass to the setValue method', () => {
+        promiseStore.then((store) => {
+            const keyErrMsg = 'The "key" parameter must be a non-empty string';
+            expect(() => { store.setValue(); }).to.throw(Error, keyErrMsg);
+            expect(() => { store.setValue('', null); }).to.throw(Error, keyErrMsg);
+            expect(() => { store.setValue('', 'some value'); }).to.throw(Error, keyErrMsg);
+            expect(() => { store.setValue({}, 'some value'); }).to.throw(Error, keyErrMsg);
+            expect(() => { store.setValue(123, 'some value'); }).to.throw(Error, keyErrMsg);
+
+            const valueErrMsg = 'The "value" parameter must be a String or Buffer when "contentType" is specified';
+            expect(() => { store.setValue('key', {}, { contentType: 'image/png' }); }).to.throw(Error, valueErrMsg);
+            expect(() => { store.setValue('key', 12345, { contentType: 'image/png' }); }).to.throw(Error, valueErrMsg);
+            expect(() => { store.setValue('key', () => { }, { contentType: 'image/png' }); }).to.throw(Error, valueErrMsg);
+
+            const optsErrMsg = 'The "options" parameter must be an object, null or undefined';
+            expect(() => { store.setValue('key', {}, 123); }).to.throw(Error, optsErrMsg);
+            expect(() => { store.setValue('key', {}, 'bla/bla'); }).to.throw(Error, optsErrMsg);
+            expect(() => { store.setValue('key', {}, true); }).to.throw(Error, optsErrMsg);
+
+            const circularObj = {};
+            circularObj.xxx = circularObj;
+            const jsonErrMsg = 'The "value" parameter cannot be stringified to JSON';
+            expect(() => { store.setValue('key', circularObj, null); }).to.throw(Error, jsonErrMsg);
+            expect(() => { store.setValue('key', undefined); }).to.throw(Error, jsonErrMsg);
+            expect(() => { store.setValue('key', () => { }); }).to.throw(Error, jsonErrMsg);
+            expect(() => { store.setValue('key'); }).to.throw(Error, jsonErrMsg);
+
+            const contTypeRedundantErrMsg = 'The "options.contentType" parameter must not be used when removing the record';
+            expect(() => { store.setValue('key', null, { contentType: 'image/png' }); }).to.throw(Error, contTypeRedundantErrMsg);
+            expect(() => { store.setValue('key', null, { contentType: '' }); }).to.throw(Error, contTypeRedundantErrMsg);
+            expect(() => { store.setValue('key', null, { contentType: {} }); }).to.throw(Error, contTypeRedundantErrMsg);
+
+            const contTypeStringErrMsg = 'The "options.contentType" parameter must be a non-empty string, null or undefined';
+            expect(() => { store.setValue('key', 'value', { contentType: 123 }); }).to.throw(Error, contTypeStringErrMsg);
+            expect(() => { store.setValue('key', 'value', { contentType: {} }); }).to.throw(Error, contTypeStringErrMsg);
+            expect(() => { store.setValue('key', 'value', { contentType: new Date() }); }).to.throw(Error, contTypeStringErrMsg);
+            expect(() => { store.setValue('key', 'value', { contentType: '' }); }).to.throw(Error, contTypeStringErrMsg);
+        });
+    });
+
+    const testStore = storeFabric('my-test-store');
+    it('returns an empty INPUT value from non-existent key in getValue method', () => {
+        testStore.then((store) => {
+            return store.getValue('INPUT').then((input) => {
+                expect(input).to.be.a('string');
+                expect(input).to.eql('');
+            }).catch(error => console.log('Oh no! 1', error));
+        }).catch(error => console.log('Oh no! 2', error));
+    });
+
+    // const setValueStore = storeFabric('my-setValue-store');
+    // it('returns STATE value after calling setValue method', () => {
+    //     const mockState = JSON.stringify({
+    //         testString: 'String',
+    //         testNumber: 3e6,
+    //         testArray: [1, 2, 3, 4],
+    //         testObject: {
+    //             key: 'value',
+    //         },
+    //     });
+    //     setValueStore.then((store) => {
+    //         return store.setValue('STATE', mockState).then(() => {
+    //             return store.getValue('STATE').then((state) => {
+    //                 expect(state).to.be.a('string');
+    //                 expect(state).to.eql(mockState);
+    //             }).catch(error => console.log('Oh no 2!', error));
+    //         });
+    //     });
+    // });
+});
+
 describe('Apify.events', () => {
     it('is there and works as EventEmitter', () => {
         return new Promise((resolve, reject) => {

--- a/test/quick-test.js
+++ b/test/quick-test.js
@@ -4,16 +4,22 @@
 //     const store = await Apify.getOrCreateStore('my-store-test');
 //     console.log(store);
 
-//     let input = await store.getValue({ key: 'INPUT' });
+//     const mock1 = {
+//         input: 'Test',
+//     };
+//     let input = await store.getValue('INPUT');
 //     console.log('INPUT', input);
+//     await store.setValue('INPUT', mock1);
+//     input = await store.getValue('INPUT');
+//     console.log('INPUT After', input);
 
 //     const mock = {
 //         name: 'Juan',
 //         lastName: 'Gaitan',
 //         middleName: 'Sebastian',
 //     };
-//     await store.setValue({ key: 'STATE', body: mock });
+//     await store.setValue('STATE', { mock });
 
-//     const nextInput = await store.getValue({ key: 'STATE' });
+//     const nextInput = await store.getValue('STATE');
 //     console.log(nextInput);
 // });

--- a/test/quick-test.js
+++ b/test/quick-test.js
@@ -1,0 +1,19 @@
+// const Apify = require('../build/index');
+
+// Apify.main(async () => {
+//     const store = await Apify.getOrCreateStore('my-store-test');
+//     console.log(store);
+
+//     let input = await store.getValue({ key: 'INPUT' });
+//     console.log('INPUT', input);
+
+//     const mock = {
+//         name: 'Juan',
+//         lastName: 'Gaitan',
+//         middleName: 'Sebastian',
+//     };
+//     await store.setValue({ key: 'STATE', body: mock });
+
+//     const nextInput = await store.getValue({ key: 'STATE' });
+//     console.log(nextInput);
+// });


### PR DESCRIPTION
Gets or creates a key-value store with the passed name or ID. The key-value store is retrieved or created automatically for each act run. The ID is passed by the user calling the function instead of the `APIFY_DEFAULT_KEY_VALUE_STORE_ID` environment variable passed by the Actor platform.

It exposes a class with two methods: `getValue` and `setValue`.

Example: 
```javascript
const Store = Apify.getOrCreateStore('My-custom-store');
const previousState = await Store.getValue('STATE');
...
const nextState = {...};
await Store.setValue('STATE');

```